### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --upgrade -r /app/requirements.txt
 
 CMD []
 
-ENTRYPOINT ["python3.4", "/app/xsstrike"]
+ENTRYPOINT ["python3.4", "/app/xsstrike.py"]


### PR DESCRIPTION
Fix : python3.4: can't open file '/app/xsstrike': [Errno 2] No such file or directory